### PR TITLE
feature/WR-XXXX-fix-error-in-dependabot-workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,13 @@ updates:
     #   - "Retail-Success/leads"
     # Will enable once stable.
     groups:
+      storybook:
+        patterns:
+          - "@storybook/*"
+          - "storybook"
+          - "storybook-*"
+          - "@chromatic-com/*"
+          - "chromatic"
       dependencies-minor:
         # Open PR for all minor updates from "dependencies" in package.json
         dependency-type: "production"
@@ -71,8 +78,8 @@ updates:
           - "patch"
       security:
         # Open PR for all security updates from "dependencies" in package.json
-        applies-to: security-updates
         dependency-type: "production"
+        applies-to: security-updates
 
   # Enable version updates for NuGet
   # - package-ecosystem: "nuget"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,9 +1,8 @@
 name: 🤖 Dependabot Automations
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
-    branches: [main]
 
 permissions:
   contents: write
@@ -18,73 +17,22 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
-          github-token: ${{ github.token }}
-          compat-lookup: true
-          alert-lookup: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve & Merge Dependabot Patch
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        uses: fastify/github-action-merge-dependabot@v3
-        with:
-          github-token: ${{ secrets.PAT_DEPENDABOT }}
-          # merge-method: squash
-          target: patch
-          # approve-only: false
-          # use-github-auto-merge: true
-
-      - name: Approve & Merge Dependabot Minor
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
-          fromJSON(steps.metadata.outputs.compatibility-score || '0') >= 80
-        uses: fastify/github-action-merge-dependabot@v3
-        with:
-          github-token: ${{ secrets.PAT_DEPENDABOT }}
-          merge-method: squash
-          target: minor
-          approve-only: false
-          use-github-auto-merge: true
-
-      - name: Approve & Merge Dependabot Major
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-major' &&
-          fromJSON(steps.metadata.outputs.compatibility-score || '0') >= 90
-        uses: fastify/github-action-merge-dependabot@v3
-        with:
-          github-token: ${{ secrets.PAT_DEPENDABOT }}
-          merge-method: squash
-          target: minor
-          approve-only: false
-          use-github-auto-merge: true
-      - name: Add labels
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const updateType = '${{ steps.dependabot-metadata.outputs.dependency-type }}';
-            const labels = ['dependencies'];
-
-            if ('${{ steps.metadata.outputs.alert-state }}' !== '' || '${{ steps.metadata.outputs.dependency-group }}' === 'security') {
-              labels.push('security');
-            } else if (updateType.includes('patch')) {
-              labels.push('auto-merged');
-            } else if (updateType.includes('minor')) {
-              labels.push('auto-merged');
-            } else if (updateType.includes('major')) {
-              labels.push('requires-review');
-            }
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: labels
-            });
-
-      - name: Log major update (no automation)
-        if: |
-          steps.dependabot-metadata.outputs.dependency-type == 'version-update:semver-major' &&
-          steps.metadata.outputs.alert-state == ''
+      - name: Auto-merge based on update type
         run: |
-          echo "🚨 Major update detected - requires manual review"
-          echo "Dependency: ${{ steps.metadata.outputs.dependency-names }}"
-          echo "PR: ${{ github.event.pull_request.html_url }}"
+          UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"
+
+          if [ "$UPDATE_TYPE" = "version-update:semver-patch" ]; then
+            gh pr review --approve "$PR_URL"
+            gh pr merge --squash --auto "$PR_URL"
+          elif [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
+            SCORE_INT=$(echo "${{ steps.metadata.outputs.compatibility-score }}" | cut -d'.' -f1)
+            if [ "$SCORE_INT" -ge 80 ] 2>/dev/null; then
+              gh pr review --approve "$PR_URL"
+              gh pr merge --squash --auto "$PR_URL"
+            fi
+          fi
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,12 +1,16 @@
 name: 🤖 Dependabot Automations
+
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+
 permissions:
   contents: write
   pull-requests: write
+
 jobs:
   dependabot:
+    name: Dependabot Auto-Merge
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
@@ -15,20 +19,66 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          compat-lookup: true
+
       - name: Auto-merge based on update type
         run: |
-          UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"
+          # Save JSON to file for parsing
+          echo "$UPDATED_DEPENDENCIES_JSON" > dependencies.json
 
-          if [ "$UPDATE_TYPE" = "version-update:semver-patch" ]; then
-            gh pr review --approve "$PR_URL"
-            gh pr merge --squash --auto "$PR_URL"
-          elif [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
-            SCORE_INT=$(echo "${{ steps.metadata.outputs.compatibility-score }}" | cut -d'.' -f1)
-            if [ "$SCORE_INT" -ge 80 ] 2>/dev/null; then
-              gh pr review --approve "$PR_URL"
-              gh pr merge --squash --auto "$PR_URL"
+          # Debug: Show the full JSON content for inspection
+          echo "Debug: Content of dependencies.json:"
+          cat dependencies.json
+
+          # Initialize safe state
+          MERGE_SAFE="true"
+
+          echo "Analyzing $(jq length dependencies.json) dependencies..."
+
+          # Iterate through each dependency
+          # Format: Name|UpdateType|Score
+          while IFS="|" read -r NAME TYPE SCORE; do
+            echo "Checking $NAME..."
+            echo "  - Type: $TYPE"
+            echo "  - Score: $SCORE"
+
+            if [ "$TYPE" == "version-update:semver-patch" ]; then
+              echo "  - Result: PASS (Patch)"
+
+            elif [ "$TYPE" == "version-update:semver-minor" ]; then
+              # Default to 0 if null/empty
+              SCORE=${SCORE:-0}
+              if [ "$SCORE" -ge 80 ]; then
+                echo "  - Result: PASS (Minor with score $SCORE)"
+              else
+                echo "  - Result: FAIL (Minor with score $SCORE < 80)"
+                MERGE_SAFE="false"
+              fi
+            elif [ "$TYPE" == "version-update:semver-major" ]; then
+              # Default to 0 if null/empty
+              SCORE=${SCORE:-0}
+              if [ "$SCORE" -ge 60 ]; then
+                echo "  - Result: PASS (Major with score $SCORE)"
+              else
+                echo "  - Result: FAIL (Major with score $SCORE < 60)"
+                MERGE_SAFE="false"
+              fi
+            else
+              echo "  - Result: FAIL (Type '$TYPE' requires manual review)"
+              MERGE_SAFE="false"
             fi
+          done < <(jq -r '.[] | "\(.dependencyName)|\(.updateType)|\(.compatibilityScore // 0)"' dependencies.json)
+
+          # Final Decision
+          if [ "$MERGE_SAFE" == "true" ]; then
+            echo " All dependencies passed checks. Auto-merging..."
+            gh pr review --approve "$PR_URL" || true
+            gh pr merge --squash --auto "$PR_URL"
+          else
+            echo " One or more dependencies failed checks. Manual review required."
+            exit 0
           fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATED_DEPENDENCIES_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,13 +1,10 @@
 name: 🤖 Dependabot Automations
-
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
-
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
   dependabot:
     if: github.actor == 'dependabot[bot]'
@@ -18,7 +15,6 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Auto-merge based on update type
         run: |
           UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -26,14 +26,19 @@ jobs:
           # Save JSON to file for parsing
           echo "$UPDATED_DEPENDENCIES_JSON" > dependencies.json
 
+          if ! jq empty dependencies.json >/dev/null 2>&1; then
+            echo "No valid dependency metadata found; skipping auto-merge."
+            exit 0
+          fi
+
+          echo "Analyzing $(jq 'length' dependencies.json) dependencies..."
+
           # Debug: Show the full JSON content for inspection
           echo "Debug: Content of dependencies.json:"
           cat dependencies.json
 
           # Initialize safe state
           MERGE_SAFE="true"
-
-          echo "Analyzing $(jq length dependencies.json) dependencies..."
 
           # Iterate through each dependency
           # Format: Name|UpdateType|Score


### PR DESCRIPTION
This pull request updates the Dependabot automation and configuration to improve dependency management and auto-merge logic. The most important changes are grouped below:

**Dependabot Workflow Automation Improvements:**

* Changed the workflow trigger from `pull_request` to `pull_request_target` to ensure the workflow has the necessary permissions for Dependabot PRs.
* Replaced the previous use of the `fastify/github-action-merge-dependabot` action with a custom shell script that parses dependency update metadata and determines whether to auto-merge based on update type and compatibility score. Patch updates are auto-merged, minor updates require a score of at least 80, and major updates require a score of at least 60.
* Updated token usage to use `${{ secrets.GITHUB_TOKEN }}` for improved security and access.

**Dependabot Configuration Enhancements:**

* Added a new dependency group `storybook` in `.github/dependabot.yml` to group updates for Storybook and related packages.
* Minor formatting and ordering fix for the `applies-to: security-updates` field in the security updates configuration.

## Summary by Sourcery

Update Dependabot workflow automation and configuration to support secure auto-merging of dependency updates based on metadata-driven rules.

New Features:
- Introduce a custom shell-based auto-merge step that evaluates Dependabot update type and compatibility score before merging PRs.
- Add a Storybook dependency group in Dependabot configuration to batch updates for Storybook-related packages.

Bug Fixes:
- Fix Dependabot workflow permission issues that prevented automation from running correctly on Dependabot-authored PRs.

Enhancements:
- Switch the Dependabot workflow trigger to pull_request_target and adjust job naming for clearer automation context.
- Update Dependabot workflow to use the default GITHUB_TOKEN instead of a custom PAT for metadata fetching and PR operations.
- Relax and centralize merge rules so patch updates always auto-merge, minor updates require a high compatibility score, and major updates can auto-merge with a lower threshold.

CI:
- Refine Dependabot CI workflow to replace the third-party auto-merge action with a GitHub CLI-based implementation driven by dependency metadata JSON.

Chores:
- Tidy Dependabot configuration formatting and correct the placement of the applies-to: security-updates setting in the security group.